### PR TITLE
oui-ui-core: add some minor fixes

### DIFF
--- a/oui-bwm/Makefile
+++ b/oui-bwm/Makefile
@@ -28,7 +28,7 @@ endef
 
 MAKE_OPTS:= \
 	$(KERNEL_MAKE_FLAGS) \
-	SUBDIRS="$(PKG_BUILD_DIR)"
+	M="$(PKG_BUILD_DIR)"
 
 define Build/Compile
 	$(MAKE) -C "$(LINUX_DIR)" \

--- a/oui-node/Makefile
+++ b/oui-node/Makefile
@@ -48,7 +48,7 @@ HOST_CONFIGURE_VARS:=
 HOST_CONFIGURE_ARGS:= \
 	--dest-os=linux \
 	--without-snapshot \
-	--prefix=$(STAGING_DIR_HOST)/
+	--prefix=$(STAGING_DIR_HOSTPKG)/
 
 HOST_CONFIGURE_CMD:=python ./configure
 

--- a/oui-ui-core/Makefile
+++ b/oui-ui-core/Makefile
@@ -64,6 +64,8 @@ endef
 
 define Package/oui-ui-core/postinst
 #!/bin/sh
+[ -z "$${IPKG_INSTROOT}" ]; && exit 0
+
 uci batch <<-EOF
 	set uhttpd.main.ubus_prefix="/ubus"
 	set uhttpd.main.index_page='oui.html'

--- a/oui-ui-core/Makefile
+++ b/oui-ui-core/Makefile
@@ -52,8 +52,8 @@ ifneq ($(CONFIG_OUI_USE_HOST_NODE),)
   MAKE_VARS += NODE=$(shell PATH=/usr/bin:/usr/local/bin which node)
   MAKE_VARS += NPM=$(shell PATH=/usr/bin:/usr/local/bin which npm)
 else
-  MAKE_VARS += NODE=$(STAGING_DIR_HOST)/bin/node
-  MAKE_VARS += NPM=$(STAGING_DIR_HOST)/bin/npm
+  MAKE_VARS += NODE=$(STAGING_DIR_HOSTPKG)/bin/node
+  MAKE_VARS += NPM=$(STAGING_DIR_HOSTPKG)/bin/npm
 endif
 
 define Package/oui-ui-core/install

--- a/oui-ui-core/Makefile
+++ b/oui-ui-core/Makefile
@@ -72,6 +72,7 @@ uci batch <<-EOF
 	commit uhttpd
 EOF
 /etc/init.d/uhttpd restart
+/etc/init.d/rpcd restart
 exit 0
 endef
 

--- a/oui-ui-core/Makefile
+++ b/oui-ui-core/Makefile
@@ -71,7 +71,7 @@ uci batch <<-EOF
 	set uhttpd.main.index_page='oui.html'
 	commit uhttpd
 EOF
-/etc/init.d/uhttpd restart &
+/etc/init.d/uhttpd restart
 exit 0
 endef
 


### PR DESCRIPTION
Add some minor fixes and also add rebuild possibility against openwrt master.

- oui-bwm: replace SUBDIRS with M in packages recipes
- oui-node: fix node staging dir definition
- oui-ui-core: fix node staging dir definition
- oui-ui-core: do not run postinst on buildroot
- oui-ui-core: detach is not necessary in service restart
- oui-ui-core: also restart rpcd on installation 