### PR TITLE
确保每次打包生成不同文件名

### DIFF
--- a/oui-ui-core/src/vue.config.js
+++ b/oui-ui-core/src/vue.config.js
@@ -1,3 +1,5 @@
+const Timestamp = new Date().getTime();
+
 module.exports = {
   indexPath: 'oui.html',
   productionSourceMap: false,
@@ -23,6 +25,12 @@ module.exports = {
       fallbackLocale: 'en',
       localeDir: 'locales',
       enableInSFC: false
+    }
+  },
+  configureWebpack: {
+    output: {
+      filename: `js/[name].[hash:8].${Timestamp}.js`,
+      chunkFilename: `js/[name].[hash:8].${Timestamp}.js`
     }
   }
 }


### PR DESCRIPTION
在打包文件中增加时间相关的标记，确保每次打包生成不同的文件名。解决了更新 oui-app-* 代码时打包生成的文件名不变，从而导致浏览器缓存旧打包文件的问题。