### PR TITLE
oui-ui-core: add typescript support

### DIFF
--- a/applications/oui-app-layout/htdoc/package.json
+++ b/applications/oui-app-layout/htdoc/package.json
@@ -14,6 +14,7 @@
     "@vicons/material": "^0.12.0",
     "@vicons/tabler": "^0.12.0",
     "@vitejs/plugin-vue": "^3.1.2",
+    "@types/oui": "../../../oui-ui-core/htdoc/oui_types",
     "vite": "^3.1.6",
     "vite-plugin-compression": "^0.5.1",
     "vue-i18n": "^9.2.2"

--- a/applications/oui-app-layout/htdoc/tsconfig.json
+++ b/applications/oui-app-layout/htdoc/tsconfig.json
@@ -1,0 +1,54 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "module": "esnext",
+    "moduleResolution": "node",
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "allowSyntheticDefaultImports": true,
+    "strictFunctionTypes": false,
+    "jsx": "preserve",
+    "baseUrl": ".",
+    "allowJs": true,
+    "sourceMap": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "experimentalDecorators": true,
+    "preserveSymlinks": true,
+    "lib": [
+      "dom",
+      "esnext"
+    ],
+    "noImplicitAny": false,
+    "skipLibCheck": true,
+    "paths": {
+      "@/*": [
+        "src/*"
+      ],
+      "/#/*": [
+        "types/*"
+      ]
+    }
+  },
+  "include": [
+    "src/**/*.ts",
+    "src/**/*.d.ts",
+    "src/**/*.tsx",
+    "src/**/*.vue",
+    "types/**/*.d.ts",
+    "types/**/*.ts",
+    "build/**/*.ts",
+    "build/**/*.d.ts",
+    "mock/**/*.ts",
+    "*.vue",
+    "components.d.ts",
+    "vite.config.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "**/*.js"
+  ]
+}

--- a/applications/oui-app-layout/htdoc/types/global.d.ts
+++ b/applications/oui-app-layout/htdoc/types/global.d.ts
@@ -1,0 +1,11 @@
+import OUI from '@types/oui'
+
+declare module '@vue/runtime-core' {
+  interface ComponentCustomProperties {
+    $oui: OUI.IOui
+    $timer: OUI.ITimer
+    $md5: OUI.IMd5
+  }
+}
+
+export {}

--- a/oui-ui-core/htdoc/oui_types/index.d.ts
+++ b/oui-ui-core/htdoc/oui_types/index.d.ts
@@ -5,15 +5,15 @@ declare namespace OUI {
       theme: string;
       hostname: string;
     };
-    call(mod: string, func: string, param: any?): Promise<any>;
-    ubus(func: string, method: string, param: any?): Promise<any>;
+    call(mod: string, func: string, param: any): Promise<any>;
+    ubus(func: string, method: string, param: any): Promise<any>;
     login(user: string, passwd: string): Promise<void>;
     logout(): Promise<void>;
     setLocale(locale: string): Promise<void>;
     setTheme(theme: string): Promise<void>;
     setHostname(name: string): Promise<void>;
     reloadConfig(configName: string): Promise<any>;
-    reconnect(delay: number?): Promise<void>;
+    reconnect(delay: number | null | undefined): Promise<void>;
   }
 
   /* copied from @types/js-md5 */

--- a/oui-ui-core/htdoc/oui_types/index.d.ts
+++ b/oui-ui-core/htdoc/oui_types/index.d.ts
@@ -1,0 +1,56 @@
+declare namespace OUI {
+  interface IOui {
+    state: {
+      locale: string;
+      theme: string;
+      hostname: string;
+    };
+    call(mod: string, func: string, param: any?): Promise<any>;
+    ubus(func: string, method: string, param: any?): Promise<any>;
+    login(user: string, passwd: string): Promise<void>;
+    logout(): Promise<void>;
+    setLocale(locale: string): Promise<void>;
+    setTheme(theme: string): Promise<void>;
+    setHostname(name: string): Promise<void>;
+    reloadConfig(configName: string): Promise<any>;
+    reconnect(delay: number?): Promise<void>;
+  }
+
+  /* copied from @types/js-md5 */
+  type message = string | any[] | Uint8Array | ArrayBuffer;
+  interface Md5 {
+    array(): number[];
+    arrayBuffer(): ArrayBuffer;
+    buffer(): ArrayBuffer;
+    digest(): number[];
+    hex(): string;
+    toString(): string;
+    update(message: message): Md5;
+    base64(): string;
+  }
+  interface IMd5 {
+    (message: message): string;
+    hex(message: message): string;
+    array(message: message): number[];
+    digest(message: message): number[];
+    arrayBuffer(message: message): ArrayBuffer;
+    buffer(message: message): ArrayBuffer;
+    create(): Md5;
+    update(message: message): Md5;
+    base64(message: message): string;
+  }
+
+  type timercb = () => void;
+  type TimerOption = {
+    time: number;
+    autostart: boolean;
+    immediate: boolean;
+    repeat: boolean;
+  }
+  interface ITimer {
+    create(name: string, callback: timercb, options: TimerOption): void;
+    start(name: string): void;
+    stop(name: string): void;
+  }
+}
+export default OUI;

--- a/oui-ui-core/htdoc/tsconfig.json
+++ b/oui-ui-core/htdoc/tsconfig.json
@@ -1,0 +1,46 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "module": "esnext",
+    "moduleResolution": "node",
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "allowSyntheticDefaultImports": true,
+    "strictFunctionTypes": false,
+    "jsx": "preserve",
+    "baseUrl": ".",
+    "allowJs": true,
+    "sourceMap": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "experimentalDecorators": true,
+    "preserveSymlinks": true,
+    "lib": [
+      "dom",
+      "esnext"
+    ],
+    "noImplicitAny": false,
+    "skipLibCheck": true
+  },
+  "include": [
+    "src/**/*.ts",
+    "src/**/*.d.ts",
+    "src/**/*.tsx",
+    "src/**/*.vue",
+    "types/**/*.d.ts",
+    "types/**/*.ts",
+    "build/**/*.ts",
+    "build/**/*.d.ts",
+    "mock/**/*.ts",
+    "*.vue",
+    "components.d.ts",
+    "vite.config.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "**/*.js"
+  ]
+}

--- a/oui-ui-core/htdoc/types/global.d.ts
+++ b/oui-ui-core/htdoc/types/global.d.ts
@@ -1,0 +1,11 @@
+import OUI from '../oui_types'
+
+declare module '@vue/runtime-core' {
+  interface ComponentCustomProperties {
+    $oui: OUI.IOui
+    $md5: OUI.IMd5
+    $timer: OUI.ITimer
+  }
+}
+
+export {}


### PR DESCRIPTION
Add typescript support.
OUI's $oui $timer $md5 api typedefs are in oui-ui-core/oui_types.
App wants to use these typedefs should
1. Add `"@types/oui": "../../../oui-ui-core/htdoc/oui_types"` to devDependencies in its own package.json.
2. Add tsconfig.json and declare @vue/runtime-core somewhere.
3. See oui-app-layout for example.