### PR TITLE
oui.mk: allow applications to omit htdoc folder

### DIFF
--- a/oui.mk
+++ b/oui.mk
@@ -23,18 +23,24 @@ define Package/$(PKG_NAME)
 endef
 
 define Build/Prepare
-	$(CP) ./htdoc $(PKG_BUILD_DIR)
-	echo "VITE_APP_NAME=$(APP_NAME)" > $(PKG_BUILD_DIR)/htdoc/.env.local
-	$(NPM) --prefix $(PKG_BUILD_DIR)/htdoc install
+	if [ -d ./htdoc ]; then \
+		$(CP) ./htdoc $(PKG_BUILD_DIR); \
+		echo "VITE_APP_NAME=$(APP_NAME)" > $(PKG_BUILD_DIR)/htdoc/.env.local; \
+		$(NPM) --prefix $(PKG_BUILD_DIR)/htdoc install; \
+	fi
 endef
 
 define Build/Compile
-	$(NPM) --prefix $(PKG_BUILD_DIR)/htdoc run build
+	if [ -d $(PKG_BUILD_DIR)/htdoc ]; then \
+		$(NPM) --prefix $(PKG_BUILD_DIR)/htdoc run build; \
+	fi
 endef
 
 define Package/$(PKG_NAME)/install
-	$(INSTALL_DIR) $(1)/www/views
-	$(CP) $(PKG_BUILD_DIR)//htdoc/dist/* $(1)/www/views
+	if [ -d $(PKG_BUILD_DIR)/htdoc/dist ]; then \
+		$(INSTALL_DIR) $(1)/www/views; \
+		$(CP) $(PKG_BUILD_DIR)/htdoc/dist/* $(1)/www/views; \
+	fi
 	if [ -f ./files/menu.json ]; then \
 		$(INSTALL_DIR) $(1)/usr/share/oui/menu.d; \
 		$(INSTALL_CONF) ./files/menu.json $(1)/usr/share/oui/menu.d/$(APP_NAME).json; \


### PR DESCRIPTION
This is useful for "root" applications which provide top-level menu entries and/or RPC files without defining any views.