### PR TITLE
oui.mk: after bundling an application delete its node_modules directory

### DIFF
--- a/oui.mk
+++ b/oui.mk
@@ -25,15 +25,15 @@ endef
 define Build/Prepare
 	if [ -d ./htdoc ]; then \
 		$(CP) ./htdoc $(PKG_BUILD_DIR); \
-		echo "VITE_APP_NAME=$(APP_NAME)" > $(PKG_BUILD_DIR)/htdoc/.env.local; \
-		$(NPM) --prefix $(PKG_BUILD_DIR)/htdoc install; \
+		echo "VITE_APP_NAME=$(APP_NAME)" > $(PKG_BUILD_DIR)/htdoc/.env.local
 	fi
 endef
 
 define Build/Compile
 	if [ -d $(PKG_BUILD_DIR)/htdoc ]; then \
-		$(NPM) --prefix $(PKG_BUILD_DIR)/htdoc run build; \
-		$(RM) -rf $(PKG_BUILD_DIR)/htdoc/node_modules; \
+		$(NPM) --prefix $(PKG_BUILD_DIR)/htdoc install && \
+		$(NPM) --prefix $(PKG_BUILD_DIR)/htdoc run build && \
+		$(RM) -rf $(PKG_BUILD_DIR)/htdoc/node_modules
 	fi
 endef
 

--- a/oui.mk
+++ b/oui.mk
@@ -33,6 +33,7 @@ endef
 define Build/Compile
 	if [ -d $(PKG_BUILD_DIR)/htdoc ]; then \
 		$(NPM) --prefix $(PKG_BUILD_DIR)/htdoc run build; \
+		$(RM) -rf $(PKG_BUILD_DIR)/htdoc/node_modules; \
 	fi
 endef
 


### PR DESCRIPTION
node_modules folder is not used by the built application and leaving it in the build directory consumes scarce filesystem inodes.

When multiple applications are present, it's easy to reach the filesystem's available inode count.

(this may have to do with me importing `element-plus` and `@element-plus/icons-vue` in applications; but it is generally useful nonetheless)