### PR TITLE
oui-ui-core: allow injecting "$oui" in apps

### DIFF
--- a/oui-ui-core/htdoc/src/oui/index.js
+++ b/oui-ui-core/htdoc/src/oui/index.js
@@ -270,6 +270,7 @@ class Oui {
   install(app) {
     app.config.globalProperties.$oui = this
     app.config.globalProperties.$md5 = md5
+    app.provide('$oui', this)
   }
 }
 


### PR DESCRIPTION
When Oui instance is installed as a Vue plugin, call `app.provide` to allow Composition API based applications to use `inject` to get a reference to the plugin.

This was explored on issue #270 and seems to work well.

Closes #270