### PR TITLE
oui-rpc-core: fix wrong socket path handling

### DIFF
--- a/oui-rpc-core/files/oui.lua
+++ b/oui-rpc-core/files/oui.lua
@@ -16,8 +16,10 @@ local uci = require 'eco.uci'
 
 local rpc = require 'oui.rpc'
 
+local sock_path = '/var/run/oui.sock'
+
 eco.panic_hook = function(err)
-    os.remove('/var/run/oui-rpc.sock')
+    os.remove(sock_path)
     log.err('panic:', err)
 end
 
@@ -526,8 +528,8 @@ local function handle_scgi(c)
 end
 
 local function run_scgi_server()
-    local path = '/var/run/oui.sock'
-    local s, err = socket.listen_unix(path)
+    os.remove(sock_path)
+    local s, err = socket.listen_unix(sock_path)
     if not s then
         error(err)
     end


### PR DESCRIPTION
This fixes these issues:

1. Socket path missmatch between `panic_hook` and `run_scgi_server` functions.
2. If service is killed then previous socket is not removed so service always returns `Address already in use` error.